### PR TITLE
Update layout for Designer to fit remaining page height

### DIFF
--- a/src/Designer.tsx
+++ b/src/Designer.tsx
@@ -12,6 +12,8 @@ import {
   downloadJsonFile,
 } from "./helper";
 
+const headerHeight = 65;
+
 function App() {
   const designerRef = useRef<HTMLDivElement | null>(null);
   const designer = useRef<Designer | null>(null);
@@ -161,7 +163,7 @@ ${e}`);
         <span style={{ margin: "0 1rem" }}>/</span>
         <button onClick={onGeneratePDF}>Generate PDF</button>
       </header>
-      <div ref={designerRef} />
+      <div ref={designerRef} style={{ width: '100%', height: `calc(100vh - ${headerHeight}px)` }}/>
     </div>
   );
 }

--- a/src/FormAndViewer.tsx
+++ b/src/FormAndViewer.tsx
@@ -10,6 +10,8 @@ import {
   isJsonString,
 } from "./helper";
 
+const headerHeight = 65;
+
 type Mode = "form" | "viewer";
 
 const initTemplate = () => {
@@ -198,7 +200,7 @@ ${e}`);
         <span style={{ margin: "0 1rem" }}>/</span>
         <button onClick={onGeneratePDF}>Generate PDF</button>
       </header>
-      <div ref={uiRef} />
+      <div ref={uiRef} style={{ width: '100%', height: `calc(100vh - ${headerHeight}px)` }}/>
     </div>
   );
 }


### PR DESCRIPTION
A small update to the v3 branch:

Avoid the Designer section scrolling off the viewport which means you cannot see the Add Field button:

Before:
![Screenshot 2023-10-26 at 08 18 46](https://github.com/pdfme/pdfme-playground/assets/7068515/04fee227-1e4e-4511-9415-f250c17120a8)


After
![Screenshot 2023-10-26 at 08 16 35](https://github.com/pdfme/pdfme-playground/assets/7068515/5d0be21b-1074-4757-99f1-7fb9b50f10ff)
